### PR TITLE
Build, test, and dockerize api validation

### DIFF
--- a/.github/workflows/dotnet-ci.yml
+++ b/.github/workflows/dotnet-ci.yml
@@ -30,7 +30,7 @@ jobs:
 
     - name: Generate Swagger JSON
       run: |
-        dotnet tool install --global Swashbuckle.AspNetCore.Cli
+        dotnet tool install --global Swashbuckle.AspNetCore.Cli --version 9.0.3
         export PATH="$PATH:/home/runner/.dotnet/tools"
         swagger tofile --output swagger.json ./ApiValidationFramework/bin/Release/net8.0/ApiValidationFramework.dll v1
 


### PR DESCRIPTION
Pin Swashbuckle CLI version to resolve assembly mismatch during Swagger generation.

The CI pipeline failed to generate Swagger JSON due to a `FileNotFoundException` for `Swashbuckle.AspNetCore.Swagger`. This was caused by a version mismatch between the globally installed `Swashbuckle.AspNetCore.Cli` (9.0.4) and the project's `Swashbuckle.AspNetCore` package (9.0.3). Pinning the CLI tool to version 9.0.3 ensures compatibility.

---
<a href="https://cursor.com/background-agent?bcId=bc-8cdc439f-29a7-4f56-9bd6-e78570f18ed6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8cdc439f-29a7-4f56-9bd6-e78570f18ed6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

